### PR TITLE
Modify the PR description's section to env to prevent error

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -74,8 +74,9 @@ jobs:
           fi
 
       - name: Check PR description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          PR_BODY="${{ github.event.pull_request.body }}"
           
           if [[ -z "$PR_BODY" ]] || [[ "$PR_BODY" == "null" ]]; then
             echo "⚠️  PR description is empty!"


### PR DESCRIPTION
Move ```PR_BODY: ${{ github.event.pull_request.body }}``` to env
```bash
name: Check PR description
        env:
          PR_BODY: ${{ github.event.pull_request.body }}
        run: |
```