### PR TITLE
fix(workflow): remove test branch from push triggers

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - main
       - dev
-      - test
 
 jobs:
   branch-naming-check:


### PR DESCRIPTION
## Summary

完成 PR #16 遺漏的 test 分支清理工作，從 push 觸發器中移除 test 分支，完整實現 Option A (簡化的 GitHub Flow)。

## Changes Made

- 從 `.github/workflows/ci-checks.yml` 的 push triggers 中移除 `test` 分支

## Related

- Related to #8
- Follow-up to PR #16

## Type of Change

- [x] Bug fix (fix)